### PR TITLE
fix: adjust presence game state detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vryjs",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "VALORANT Rank Yoinker JS",
   "repository": "tanishqmanuja/valorant-rank-yoinker-js",
   "type": "module",


### PR DESCRIPTION
## Summary
- update package.json to release version 0.3.4
- expand getGameState to read sessionLoopState from match/party presence fields
- default to PREGAME when only queue info is present

## Testing
- pnpm start:dev (table renders while in-match)
- pnpm build
- out\vryjs.exe version